### PR TITLE
Generate non-contiguous ITEM_TM_MOVE/ITEM_HM_MOVE constants via R_ZIP_WITH

### DIFF
--- a/include/item.h
+++ b/include/item.h
@@ -1,6 +1,7 @@
 #ifndef GUARD_ITEM_H
 #define GUARD_ITEM_H
 
+#include "metaprogram.h"
 #include "constants/item.h"
 #include "constants/items.h"
 #include "constants/tms_hms.h"
@@ -85,6 +86,8 @@ u32 ItemId_GetFlingPower(u32 itemId);
 u32 GetItemStatus1Mask(u16 itemId);
 u32 GetItemStatus2Mask(u16 itemId);
 
+#define TMHM_NUMBERS (01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100)
+
 /* Expands to:
  * enum
  * {
@@ -93,15 +96,12 @@ u32 GetItemStatus2Mask(u16 itemId);
  *   ITEM_HM_CUT,
  *   ...
  * }; */
-#define ENUM_TM(id) CAT(ITEM_TM_, id),
-#define ENUM_HM(id) CAT(ITEM_HM_, id),
+#define ENUM_TM(n, id) CAT(ITEM_TM_, id) = CAT(ITEM_TM, n),
+#define ENUM_HM(n, id) CAT(ITEM_HM_, id) = CAT(ITEM_HM, n),
 enum
 {
-    ENUM_TM_START_ = ITEM_TM01 - 1,
-    FOREACH_TM(ENUM_TM)
-
-    ENUM_HM_START_ = ITEM_HM01 - 1,
-    FOREACH_HM(ENUM_HM)
+    RECURSIVELY(R_ZIP_WITH(ENUM_TM, TMHM_NUMBERS, (FOREACH_TM(APPEND_COMMA))))
+    RECURSIVELY(R_ZIP_WITH(ENUM_HM, TMHM_NUMBERS, (FOREACH_HM(APPEND_COMMA))))
 };
 #undef ENUM_TM
 #undef ENUM_HM

--- a/include/metaprogram.h
+++ b/include/metaprogram.h
@@ -28,6 +28,7 @@
 
 /* You'll never guess what this one does */
 #define APPEND_SEMICOLON(a) a;
+#define APPEND_COMMA(a) a,
 
 /* Converts a string to a compound literal, essentially making it a pointer to const u8 */
 #define COMPOUND_STRING(str) (const u8[]) _(str)
@@ -80,6 +81,18 @@
 #define R_FOR_EACH_WITH(macro, args, ...) __VA_OPT__(R_FOR_EACH_WITH_(macro, args, __VA_ARGS__))
 #define R_FOR_EACH_WITH_(macro, args, a, ...) INVOKE_WITH(macro, args, a) __VA_OPT__(R_FOR_EACH_WITH_P PARENS (macro, args, __VA_ARGS__))
 #define R_FOR_EACH_WITH_P() R_FOR_EACH_WITH_
+
+/* Expands to 'macro(a, b)' for each 'a' in 'as' and 'b' in 'bs'.
+ * Uses the shorter of 'as' and 'bs'. */
+#define R_ZIP_WITH(macro, as, bs) CAT(R_ZIP_WITH_, CAT(R_ZIP_WITH_NONEMPTY(as), R_ZIP_WITH_NONEMPTY(bs)))(macro, FIRST as, FIRST bs, (EXCEPT_1 as), (EXCEPT_1 bs))
+#define R_ZIP_WITH_00(macro, a, b, as, bs)
+#define R_ZIP_WITH_01(macro, a, b, as, bs)
+#define R_ZIP_WITH_10(macro, a, b, as, bs)
+#define R_ZIP_WITH_11(macro, a, b, as, bs) macro(a, b) R_ZIP_WITH_P PARENS (macro, as, bs)
+#define R_ZIP_WITH_P() R_ZIP_WITH
+
+#define R_ZIP_WITH_NONEMPTY(as) R_ZIP_WITH_NONEMPTY_ as
+#define R_ZIP_WITH_NONEMPTY_(...) FIRST(__VA_OPT__(1,) 0)
 
 /* Picks the xth VA_ARG if it exists, otherwise returns a default value */
 #define DEFAULT(_default, ...) FIRST(__VA_OPT__(__VA_ARGS__, ) _default)


### PR DESCRIPTION
The trick here is `RECURSIVELY(R_ZIP_WITH(ENUM_TM, TMHM_NUMBERS, (FOREACH_TM(APPEND_COMMA))))` which first expands to:
```
RECURSIVELY(R_ZIP_WITH(ENUM_TM, (01, 02, 03, ...), (FOCUS_PUNCH, DRAGON_CLAW, CALM_MIND, ...)))
```
And then `R_ZIP_WITH` turns that into:
```
ENUM_TM(01, FOCUS_PUNCH) ENUM_TM(02, DRAGON_CLAW) ENUM_TM(03, CALM_MIND) ...
```
Which finally expands to:
```
ITEM_TM_FOCUS_PUNCH = ITEM_TM01, ITEM_TM_DRAGON_CLAW = ITEM_TM02, ITEM_TM_CALM_MIND = ITEM_TM03,
```