### PR TITLE
Text fixes

### DIFF
--- a/src/battle_ai_main.c
+++ b/src/battle_ai_main.c
@@ -5578,7 +5578,6 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
             switch (additionalEffect->moveEffect)
             {
             case MOVE_EFFECT_STAT_PLUS:
-            case MOVE_EFFECT_STAT_MINUS:
                 for (enum Stat i = STAT_ATK; i < NUM_BATTLE_STATS; i++)
                 {
                     enum Stat stat = sAccurateStatOrder[i];
@@ -5587,8 +5586,23 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
                     if (stage == 0)
                         continue;
 
-                    if (additionalEffect->moveEffect == MOVE_EFFECT_STAT_MINUS)
+                    if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                         stage = -1 * stage;
+
+                    if (stage < 0)
+                        continue;
+
+                    ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage));
+                }
+                break;
+            case MOVE_EFFECT_STAT_MINUS:
+                for (enum Stat i = STAT_ATK; i < NUM_BATTLE_STATS; i++)
+                {
+                    enum Stat stat = sAccurateStatOrder[i];
+                    s32 stage = -1 * GetStatStage(stat, additionalEffect);
+
+                    if (stage == 0)
+                        continue;
 
                     if (aiData->abilities[battlerAtk] == ABILITY_CONTRARY)
                         stage = -1 * stage;
@@ -5596,9 +5610,7 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
                     if (stage < 0)
                         continue;
 
-                    if (IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage) > WEAK_EFFECT)
-                    // if (gBattleMons[battlerAtk].statStages[stat] < MAX_STAT_STAGE)
-                        ADJUST_SCORE(DECENT_EFFECT);
+                    ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, stat));
                 }
                 break;
             case MOVE_EFFECT_ORDER_UP:
@@ -5638,7 +5650,6 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
             switch (additionalEffect->moveEffect)
             {
             case MOVE_EFFECT_STAT_PLUS:
-            case MOVE_EFFECT_STAT_MINUS:
                 for (enum Stat stat = STAT_ATK; stat < NUM_BATTLE_STATS; stat++)
                 {
                     s32 stage = GetStatStage(stat, additionalEffect);
@@ -5646,8 +5657,21 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
                     if (stage == 0)
                         continue;
 
-                    if (additionalEffect->moveEffect == MOVE_EFFECT_STAT_MINUS)
+                    if (aiData->abilities[battlerDef] == ABILITY_CONTRARY)
                         stage = -1 * stage;
+
+                    if (stage > 0)
+                        continue;
+
+                    ADJUST_SCORE(IncreaseStatUpScore(battlerAtk, battlerDef, stat, stage));
+                }
+            case MOVE_EFFECT_STAT_MINUS:
+                for (enum Stat stat = STAT_ATK; stat < NUM_BATTLE_STATS; stat++)
+                {
+                    s32 stage = -1 * GetStatStage(stat, additionalEffect);
+
+                    if (stage == 0)
+                        continue;
 
                     if (aiData->abilities[battlerDef] == ABILITY_CONTRARY)
                         stage = -1 * stage;
@@ -5655,9 +5679,7 @@ static s32 AI_CalcAdditionalEffectScore(enum BattlerId battlerAtk, enum BattlerI
                     if (stage > 0)
                         continue;
 
-                    if (IncreaseStatDownScore(battlerAtk, battlerDef, stat) > WEAK_EFFECT)
-                    // if (gBattleMons[battlerDef].statStages[stat] > MIN_STAT_STAGE)
-                        ADJUST_SCORE(DECENT_EFFECT);
+                    ADJUST_SCORE(IncreaseStatDownScore(battlerAtk, battlerDef, stat));
                 }
                 break;
             case MOVE_EFFECT_FLINCH:

--- a/src/battle_ai_util.c
+++ b/src/battle_ai_util.c
@@ -2355,6 +2355,10 @@ enum AIScore IncreaseStatDownScore(enum BattlerId battlerAtk, enum BattlerId bat
     if (DoesAbilityRaiseStatsWhenLowered(gAiLogicData->abilities[battlerDef]))
         return NO_INCREASE;
 
+    // Don't increase score if AI can just KO
+    if (GetNoOfHitsToKOBattlerDmg(GetBestDmgFromBattler(battlerAtk, battlerDef, AI_ATTACKING), battlerDef) == 1)
+        return NO_INCREASE;
+
     // TODO: Avoid decreasing stat if
     // player can kill ai in 2 hits with decreased attack / sp atk stages
     // ai can kill target in 2 hits without decreasing defense / sp def stages

--- a/test/battle/ai/ai.c
+++ b/test/battle/ai/ai.c
@@ -4,27 +4,14 @@
 
 AI_SINGLE_BATTLE_TEST("AI prefers Bubble over Water Gun if it's slower")
 {
-    u32 speedPlayer, speedAi;
-
-    PARAMETRIZE { speedPlayer = 200; speedAi = 10; }
-    PARAMETRIZE { speedPlayer = 10; speedAi = 200; }
-
     GIVEN {
         ASSUME(GetMovePower(MOVE_WATER_GUN) == GetMovePower(MOVE_BUBBLE));
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_CHECK_VIABILITY | AI_FLAG_TRY_TO_FAINT);
-        PLAYER(SPECIES_SCIZOR) { Speed(speedPlayer); }
-        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_WATER_GUN, MOVE_BUBBLE); Speed(speedAi); }
+        PLAYER(SPECIES_SCIZOR) { Speed(200); }
+        OPPONENT(SPECIES_WOBBUFFET) { Moves(MOVE_WATER_GUN, MOVE_BUBBLE); Speed(10); }
     } WHEN {
-        if (speedPlayer > speedAi)
-        {
-            TURN { SCORE_GT(opponent, MOVE_BUBBLE, MOVE_WATER_GUN); }
-            TURN { SCORE_GT(opponent, MOVE_BUBBLE, MOVE_WATER_GUN); }
-        }
-        else
-        {
-            TURN { SCORE_EQ(opponent, MOVE_BUBBLE, MOVE_WATER_GUN); }
-            TURN { SCORE_EQ(opponent, MOVE_BUBBLE, MOVE_WATER_GUN); }
-        }
+        TURN { SCORE_GT(opponent, MOVE_BUBBLE, MOVE_WATER_GUN); }
+        TURN { SCORE_GT(opponent, MOVE_BUBBLE, MOVE_WATER_GUN); }
     }
 }
 
@@ -315,7 +302,7 @@ AI_SINGLE_BATTLE_TEST("AI scores KOs with two turn moves correctly, considering 
         PLAYER(SPECIES_ZIGZAGOON) { Moves(MOVE_CELEBRATE); HP(5); }
         OPPONENT(SPECIES_ZIGZAGOON) { Moves(MOVE_FOCUS_BLAST, MOVE_SKULL_BASH, MOVE_FIERY_DANCE, MOVE_CRABHAMMER); Item(aiItem); }
     } WHEN {
-        TURN { aiItem == ITEM_POWER_HERB ? EXPECT_MOVE(opponent, MOVE_SKULL_BASH) : SCORE_EQ(opponent, MOVE_FIERY_DANCE); }
+        TURN { aiItem == ITEM_POWER_HERB ? EXPECT_MOVE(opponent, MOVE_SKULL_BASH) : SCORE_EQ(opponent, MOVE_FIERY_DANCE, MOVE_SKULL_BASH); }
     }
 }
 

--- a/test/battle/ai/ai_doubles.c
+++ b/test/battle/ai/ai_doubles.c
@@ -987,6 +987,7 @@ AI_DOUBLE_BATTLE_TEST("AI uses Helping Hand if it's about to die")
 
 AI_DOUBLE_BATTLE_TEST("AI uses Helping Hand if the ally does notably more damage")
 {
+    KNOWN_FAILING;  // Failure was masked by test runner issues
     GIVEN {
         ASSUME(GetMoveEffect(MOVE_HELPING_HAND) == EFFECT_HELPING_HAND);
         AI_FLAGS(AI_FLAG_CHECK_BAD_MOVE | AI_FLAG_TRY_TO_FAINT | AI_FLAG_CHECK_VIABILITY | AI_FLAG_OMNISCIENT);


### PR DESCRIPTION
## Description
- Reverted the Fiery Dance / Skull Bash test to current upcoming, as the logic was fixed
- Reverted the removed `KNOWN_FAILING`, as with the fixed logic it continues to fail
- Integrated `IncreaseStatUpScore` and `IncreaseStatDownScore` fully into the new system
- Added a check in `IncreaseStatDownScore` to not increase score if the AI could instead just KO
- There was no reason for the AI to ever Water Gun instead of Bubble given that they're the same base power, so adjusted the test

This might still add a frame to CI's thinking time test because of that awkward 1 frame difference between local and CI, but you can just increase the frame count by 1 if need be if that occurs :)

## **Discord contact info**
Pawkkie
